### PR TITLE
Only cache write operations in our idempotency store"

### DIFF
--- a/api/middleware/auth.go
+++ b/api/middleware/auth.go
@@ -1,9 +1,11 @@
 package middleware
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/rugwirobaker/hermes"
+	"github.com/rugwirobaker/hermes/api/render"
 	"github.com/rugwirobaker/hermes/api/request"
 	"github.com/rugwirobaker/hermes/observ"
 )
@@ -20,14 +22,17 @@ func Authenticate(apps hermes.AppStore) Middleware {
 
 			token := r.Header.Get("Authorization")
 			if token == "" {
-				http.Error(w, "Unauthorized", http.StatusUnauthorized)
+				err := fmt.Errorf("unauthorized: missing token")
+				span.RecordError(err)
+				render.HttpError(w, err)
 				return
 			}
 
 			// check if the token exists in the db
 			app, err := apps.FindByToken(ctx, token)
 			if err != nil {
-				http.Error(w, "Unauthorized", http.StatusUnauthorized)
+				span.RecordError(err)
+				render.HttpError(w, err)
 				return
 			}
 

--- a/cmd/hermes/serve.go
+++ b/cmd/hermes/serve.go
@@ -122,7 +122,17 @@ func runServe(ctx context.Context, args []string) (err error) {
 		}
 	}()
 
-	go startCleanupRoutine(ctx, db, cleanupInterval, retention)
+	// make sure we are on primary node
+	// check if we're on the primary instance
+	primary, err := db.IsPrimary()
+	if err != nil {
+		log.Printf("could not check if we're on primary node: %v", err)
+	}
+
+	if primary != "" {
+		log.Println("starting cleanup routine on primary")
+		go startCleanupRoutine(ctx, db, cleanupInterval, retention)
+	}
 
 	<-signalCh
 	log.Println("received signal, shutting down")

--- a/sqlite/cleanup.go
+++ b/sqlite/cleanup.go
@@ -4,16 +4,9 @@ import (
 	"context"
 	"fmt"
 	"time"
-
-	"github.com/rugwirobaker/hermes/observ"
 )
 
 func DeleteOldRecords(ctx context.Context, db *DB, ret time.Duration) (int64, error) {
-	const op = "CleanUpIdempotencyKeys"
-
-	ctx, span := observ.StartSpan(ctx, op)
-	defer span.End()
-
 	tx, err := db.BeginTx(ctx, TxOptions(false))
 	if err != nil {
 		return 0, fmt.Errorf("error deleting old records: %w", err)

--- a/sqlite/db.go
+++ b/sqlite/db.go
@@ -3,7 +3,10 @@ package sqlite
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
 
 	// _ "github.com/lib/pq"
 
@@ -16,7 +19,8 @@ import (
 var driver = "sqlite3"
 
 type DB struct {
-	db *sql.DB
+	db  *sql.DB
+	dsn string
 }
 
 func NewDB(dsn, server string, provider trace.TracerProvider) (*DB, error) {
@@ -34,7 +38,7 @@ func NewDB(dsn, server string, provider trace.TracerProvider) (*DB, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &DB{db}, nil
+	return &DB{db, dsn}, nil
 }
 
 // BeginTx starts a transaction and returns a wrapper Tx type. This type
@@ -63,6 +67,22 @@ func (db *DB) BeginTx(ctx context.Context, opts *sql.TxOptions) (*Tx, error) {
 		db:   db,
 		span: span,
 	}, nil
+}
+
+// IsPrimary checks if we're on the primary instance by reading the .primary file
+// that contains the primary instance's IP address. If the file doesn't exist we're either
+// on the primary instance or litefs is not running on the instance.
+func (db *DB) IsPrimary() (string, error) {
+	primaryFilename := filepath.Join(filepath.Dir(db.dsn), ".primary")
+
+	primary, err := os.ReadFile(primaryFilename)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return "", nil
+		}
+		return "", err
+	}
+	return string(primary), nil
 }
 
 // Close closes the database connection.


### PR DESCRIPTION
- For now we're only caching write operations because read operations might be running on a non primary node
in the future we might add an idempotency proxy that has it's own store.
- Only run the clean up routine on our primary
